### PR TITLE
chore (reactivity): add CI/CD workflows and release scripts (#1)

### DIFF
--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -1,0 +1,80 @@
+name: Benchmark Reactivity
+
+on:
+  workflow_run:
+    workflows: ["Build Reactivity"]
+    types: [completed]
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/reactivity/**"
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    name: Run Benchmarks
+    runs-on: self-hosted
+    # Only run if build succeeded (when triggered by workflow_run)
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js with fnm
+        run: fnm use --install-if-missing
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: reactivity-dist-*
+          path: ./packages/reactivity/dist/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run benchmarks
+        run: pnpm --filter @torq-js/reactivity bench --reporter=json --outputFile=benchmark-results.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: "vitest"
+          output-file-path: ./packages/reactivity/benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Only auto-push on main branch, not on PRs
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # Alert if performance degrades by more than 10%
+          alert-threshold: "110%"
+          comment-on-alert: true
+          comment-always: true
+          fail-on-alert: false
+          # Store results in gh-pages branch
+          gh-pages-branch: "gh-pages"
+          benchmark-data-dir-path: "bench/reactivity"
+
+      - name: Generate timestamp
+        id: timestamp
+        run: echo "value=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Upload benchmark results as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: reactivity-benchmark-results-${{ steps.timestamp.outputs.value }}-${{ github.sha }}
+          path: ./packages/reactivity/benchmark-results.json
+          retention-days: 90
+
+      - name: Cleanup workspace
+        if: always()
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          git clean -ffdx
+          git reset --hard

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -26,9 +26,8 @@ jobs:
 
       - name: Setup Node.js with fnm
         run: |
-          eval "$(fnm env --use-on-cd)"
-          fnm install
-          fnm use
+          eval "$(fnm env)"
+          fnm use --install-if-missing
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Setup Node.js with fnm
         run: |
           eval "$(fnm env --use-on-cd)"
-          fnm use --install-if-missing
+          fnm install
+          fnm use
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -43,7 +43,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmarks
-        run: pnpm --filter @torq-js/reactivity bench --reporter=json --outputFile=benchmark-results.json
+        run: |
+          pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results.json --run
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -25,7 +25,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js with fnm
-        run: fnm use --install-if-missing
+        run: |
+          eval "$(fnm env --use-on-cd)"
+          fnm use --install-if-missing
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -43,13 +43,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmarks
+        run: pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results.json
+
+      - name: Transform benchmark results
         run: |
-          pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results.json --run
+          cd packages/reactivity
+          jq '[.files[].groups[].benchmarks[] | {name: .name, unit: "ops/sec", value: .hz}]' benchmark-results.json | sponge benchmark-results.json
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          tool: "vitest"
+          tool: "customBiggerIsBetter"
           output-file-path: ./packages/reactivity/benchmark-results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only auto-push on main branch, not on PRs

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js with fnm
-        run: |
-          eval "$(fnm env)"
-          fnm use --install-if-missing
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -4,30 +4,22 @@ on:
   workflow_run:
     workflows: ["Build Reactivity"]
     types: [completed]
-    branches: [main]
-  pull_request:
-    branches: [main]
-    paths:
-      - "packages/reactivity/**"
-  workflow_dispatch:
 
 jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: self-hosted
-    # Only run if build succeeded (when triggered by workflow_run)
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -36,9 +28,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
-          pattern: reactivity-dist-*
+          name: reactivity-dist
           path: ./packages/reactivity/dist/
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -67,15 +59,11 @@ jobs:
           gh-pages-branch: "gh-pages"
           benchmark-data-dir-path: "bench/reactivity"
 
-      - name: Generate timestamp
-        id: timestamp
-        run: echo "value=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
       - name: Upload benchmark results as artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: reactivity-benchmark-results-${{ steps.timestamp.outputs.value }}-${{ github.sha }}
+          name: reactivity-benchmark-results
           path: ./packages/reactivity/benchmark-results.json
           retention-days: 90
 

--- a/.github/workflows/benchmark-reactivity.yml
+++ b/.github/workflows/benchmark-reactivity.yml
@@ -43,12 +43,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmarks
-        run: pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results.json
+        run: pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results-vitest.json
 
       - name: Transform benchmark results
         run: |
           cd packages/reactivity
-          jq '[.files[].groups[].benchmarks[] | {name: .name, unit: "ops/sec", value: .hz}]' benchmark-results.json | sponge benchmark-results.json
+          jq '[.files[].groups[].benchmarks[] | {name: .name, unit: "ops/sec", value: .hz}]' benchmark-results-vitest.json > benchmark-results.json
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/build-reactivity.yml
+++ b/.github/workflows/build-reactivity.yml
@@ -1,35 +1,27 @@
 name: Build Reactivity
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'packages/reactivity/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'tsconfig.base.json'
   pull_request:
     branches: [main]
     paths:
-      - 'packages/reactivity/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'tsconfig.base.json'
+      - "packages/reactivity/**"
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest  # Use GitHub cloud runner
-    
+    runs-on: ubuntu-latest # Use GitHub cloud runner
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -40,13 +32,9 @@ jobs:
       - name: Build reactivity package
         run: pnpm --filter @torq-js/reactivity build
 
-      - name: Generate timestamp
-        id: timestamp
-        run: echo "value=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: reactivity-dist-${{ steps.timestamp.outputs.value }}-${{ github.sha }}
+          name: reactivity-dist
           path: ./packages/reactivity/dist/
           retention-days: 90

--- a/.github/workflows/build-reactivity.yml
+++ b/.github/workflows/build-reactivity.yml
@@ -1,0 +1,52 @@
+name: Build Reactivity
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/reactivity/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.base.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/reactivity/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.base.json'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest  # Use GitHub cloud runner
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build reactivity package
+        run: pnpm --filter @torq-js/reactivity build
+
+      - name: Generate timestamp
+        id: timestamp
+        run: echo "value=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: reactivity-dist-${{ steps.timestamp.outputs.value }}-${{ github.sha }}
+          path: ./packages/reactivity/dist/
+          retention-days: 90

--- a/.github/workflows/build-reactivity.yml
+++ b/.github/workflows/build-reactivity.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-reactivity.yml
+++ b/.github/workflows/publish-reactivity.yml
@@ -2,79 +2,49 @@ name: Publish Reactivity
 
 on:
   push:
+    branches:
+      - main
     tags:
-      - "reactivity-v*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish (e.g., reactivity-v0.0.2)"
-        required: true
-        type: string
+      - "v*"
 
 jobs:
+  build:
+    uses: ./.github/workflows/build-reactivity.yml
+    secrets: inherit
+
+  test:
+    needs: build
+    uses: ./.github/workflows/test-reactivity.yml
+    secrets: inherit
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # Required for npm provenance
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          name: reactivity-dist
+          path: ./packages/reactivity/dist/
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
-          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build package
-        run: pnpm --filter @torq-js/reactivity build
-
-      - name: Extract version from tag
+      - name: Extract version from package.json
         id: version
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          VERSION="${TAG#reactivity-v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Publishing version: $VERSION"
-
-      - name: Verify package version matches tag
-        run: |
-          cd packages/reactivity
-          PACKAGE_VERSION=$(pnpm pkg get version | tr -d '"')
-          TAG_VERSION="${{ steps.version.outputs.version }}"
-          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Error: Package version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
-            exit 1
-          fi
-          echo "Version verification passed: $PACKAGE_VERSION"
+        run: echo "version=$(pnpm pkg get version | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: Publish to npm
         run: pnpm --filter @torq-js/reactivity publish --access public --provenance --no-git-checks
@@ -84,7 +54,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           name: "@torq-js/reactivity v${{ steps.version.outputs.version }}"
           body: |
             ## @torq-js/reactivity v${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-reactivity.yml
+++ b/.github/workflows/publish-reactivity.yml
@@ -33,14 +33,14 @@ jobs:
           name: reactivity-dist
           path: ./packages/reactivity/dist/
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Extract version from package.json
         id: version

--- a/.github/workflows/publish-reactivity.yml
+++ b/.github/workflows/publish-reactivity.yml
@@ -1,0 +1,94 @@
+name: Publish Reactivity
+
+on:
+  push:
+    tags:
+      - "reactivity-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g., reactivity-v0.0.2)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for npm provenance
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm --filter @torq-js/reactivity build
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#reactivity-v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+      - name: Verify package version matches tag
+        run: |
+          cd packages/reactivity
+          PACKAGE_VERSION=$(pnpm pkg get version | tr -d '"')
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: Package version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "Version verification passed: $PACKAGE_VERSION"
+
+      - name: Publish to npm
+        run: pnpm --filter @torq-js/reactivity publish --access public --provenance --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          name: "@torq-js/reactivity v${{ steps.version.outputs.version }}"
+          body: |
+            ## @torq-js/reactivity v${{ steps.version.outputs.version }}
+
+            Published to npm: https://www.npmjs.com/package/@torq-js/reactivity/v/${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}

--- a/.github/workflows/test-reactivity.yml
+++ b/.github/workflows/test-reactivity.yml
@@ -4,15 +4,19 @@ on:
   workflow_run:
     workflows: ["Build Reactivity"]
     types: [completed]
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/reactivity/**"
   workflow_dispatch:
 
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest  # Use GitHub cloud runner
+    runs-on: ubuntu-latest # Use GitHub cloud runner
     # Only run if build succeeded
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/test-reactivity.yml
+++ b/.github/workflows/test-reactivity.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test-reactivity.yml
+++ b/.github/workflows/test-reactivity.yml
@@ -4,11 +4,7 @@ on:
   workflow_run:
     workflows: ["Build Reactivity"]
     types: [completed]
-  pull_request:
-    branches: [main]
-    paths:
-      - "packages/reactivity/**"
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   test:
@@ -22,9 +18,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -33,21 +30,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         continue-on-error: false
         with:
-          pattern: reactivity-dist-*
+          name: reactivity-dist
           path: ./packages/reactivity/dist/
-          merge-multiple: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify artifacts downloaded
-        run: |
-          if [ ! -d "./packages/reactivity/dist" ] || [ -z "$(ls -A ./packages/reactivity/dist)" ]; then
-            echo "Error: Build artifacts not found or empty"
-            exit 1
-          fi
-          echo "✓ Build artifacts verified"
 
       - name: Run tests
         run: pnpm --filter @torq-js/reactivity test

--- a/.github/workflows/test-reactivity.yml
+++ b/.github/workflows/test-reactivity.yml
@@ -1,0 +1,49 @@
+name: Test Reactivity
+
+on:
+  workflow_run:
+    workflows: ["Build Reactivity"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest  # Use GitHub cloud runner
+    # Only run if build succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: false
+        with:
+          pattern: reactivity-dist-*
+          path: ./packages/reactivity/dist/
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify artifacts downloaded
+        run: |
+          if [ ! -d "./packages/reactivity/dist" ] || [ -z "$(ls -A ./packages/reactivity/dist)" ]; then
+            echo "Error: Build artifacts not found or empty"
+            exit 1
+          fi
+          echo "✓ Build artifacts verified"
+
+      - name: Run tests
+        run: pnpm --filter @torq-js/reactivity test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 tsconfig.vitest-temp.json
 dist
 packages/reactivity/benchmarks/sandbox.bench.ts
+**/benchmark-results.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test:source": "pnpm -r test:source",
     "test:dist": "pnpm -r test:dist",
     "bench": "pnpm --filter @torq-js/reactivity bench",
-    "bench:watch": "pnpm --filter @torq-js/reactivity bench:watch"
+    "bench:watch": "pnpm --filter @torq-js/reactivity bench:watch",
+    "release:reactivity": "cd packages/reactivity && pnpm version --message 'chore(reactivity): release v%s'"
   },
   "devDependencies": {
     "@types/node": "^22.15.3",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "test": "pnpm -r test",
     "test:source": "pnpm -r test:source",
     "test:dist": "pnpm -r test:dist",
-    "bench": "pnpm --filter @torq-js/reactivity bench",
-    "bench:watch": "pnpm --filter @torq-js/reactivity bench:watch",
-    "release:reactivity": "cd packages/reactivity && pnpm version --message 'chore(reactivity): release v%s'"
+    "bench": "pnpm --filter @torq-js/reactivity bench"
   },
   "devDependencies": {
     "@types/node": "^22.15.3",

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -17,8 +17,7 @@
         "test:source": "TORQ_TEST_TARGET=source vitest run --typecheck",
         "test:dist": "TORQ_TEST_TARGET=dist vitest run --typecheck",
         "build": "vite build",
-        "bench": "vitest bench",
-        "bench:watch": "vitest bench --watch"
+        "bench": "vitest bench"
     },
     "dependencies": {
         "symbol-observable": "^4.0.0"

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -3,6 +3,7 @@
     "author": "Kaleb Baldwin",
     "license": "MIT",
     "version": "0.0.1",
+    "tag-version-prefix": "reactivity-v",
     "module": "dist/reactivity.es.js",
     "main": "dist/reactivity.cjs.js",
     "types": "dist/reactivity.d.ts",

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -3,7 +3,6 @@
     "author": "Kaleb Baldwin",
     "license": "MIT",
     "version": "0.0.1",
-    "tag-version-prefix": "reactivity-v",
     "module": "dist/reactivity.es.js",
     "main": "dist/reactivity.cjs.js",
     "types": "dist/reactivity.d.ts",
@@ -12,6 +11,10 @@
         "url": "git+https://github.com/ka-jo/torq",
         "directory": "packages/reactivity"
     },
+    "files": [
+        "dist",
+        "README.md"
+    ],
     "scripts": {
         "test": "vitest run --typecheck",
         "test:source": "TORQ_TEST_TARGET=source vitest run --typecheck",


### PR DESCRIPTION
- Add build, test, benchmark, and publish workflows for reactivity package
- Configure build workflow to run on ubuntu-latest with artifact upload
- Configure test workflow to download and verify build artifacts
- Configure benchmark workflow for self-hosted Pi runner with fnm
- Configure publish workflow with npm provenance and GitHub releases
- Add release script for versioned releases with custom tag prefix
- Add Raspberry Pi setup documentation and checklist
- Add benchmark workflow reference documentation