### PR TITLE
Benchmark workflow updates

### DIFF
--- a/.github/workflows/reactivity-benchmark.yml
+++ b/.github/workflows/reactivity-benchmark.yml
@@ -18,12 +18,15 @@ on:
 jobs:
   benchmark:
     name: Run Benchmarks
-    runs-on: self-hosted
+    runs-on: [self-hosted, benchmark-runner]
     if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
-      - name: Init
-        uses: ./.github/workflows/actions/init-environment.yml
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run benchmarks
         run: pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results-vitest.json


### PR DESCRIPTION
Target the self-hosted, benchmark-runner runner specifically

Remove the init-environment composite action because the self-hosted runner doesn't have access to it without first checking out the code