### PR TITLE
Init action for benchmark workflow

### DIFF
--- a/.github/workflows/reactivity-benchmark.yml
+++ b/.github/workflows/reactivity-benchmark.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Init
         uses: ./.github/workflows/actions/init-environment.yml
 
+      - name: Build
+        run: pnpm --filter @torq-js/reactivity build
+
       - name: Run benchmarks
         run: pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results-vitest.json
 

--- a/.github/workflows/reactivity-benchmark.yml
+++ b/.github/workflows/reactivity-benchmark.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Init
+        uses: ./.github/workflows/actions/init-environment.yml
 
       - name: Run benchmarks
         run: pnpm --filter @torq-js/reactivity bench --outputJson=benchmark-results-vitest.json


### PR DESCRIPTION
Add init action back into benchmark workflow because I was wrong.

GitHub action runners I guess don't have access to the full environment like I thought, so pnpm needs to be installed